### PR TITLE
Remove Git submodules for Hugo themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "themes/PaperMod"]
-	path = themes/PaperMod
-	url = https://github.com/adityatelange/hugo-PaperMod.git
-[submodule "themes/ananke"]
-	path = themes/ananke
-	url = https://github.com/theNewDynamic/gohugo-theme-ananke.git


### PR DESCRIPTION
## Summary
- Removes the `.gitmodules` file which contained submodules for Hugo themes
- Specifically removes submodules for `themes/PaperMod` and `themes/ananke`
- This change likely supports replacing submodules with a direct copy of the Hugo themes in the repository

## Changes
- Deleted `.gitmodules` file that referenced:
  - `themes/PaperMod` submodule from https://github.com/adityatelange/hugo-PaperMod.git
  - `themes/ananke` submodule from https://github.com/theNewDynamic/gohugo-theme-ananke.git

## Test plan
- Verify that the repository no longer tracks these themes as git submodules
- Confirm that the Hugo themes are still available and functional in the site build after replacement
- Run site build and preview to ensure no errors related to missing themes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a11f09bc-ed56-4a9f-806e-d2a2b07185e8