### PR TITLE
Add retro theme to Hugo blog

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "themes/ananke"]
 	path = themes/ananke
 	url = https://github.com/theNewDynamic/gohugo-theme-ananke.git
+[submodule "themes/terminal"]
+	path = themes/terminal
+	url = https://github.com/panr/hugo-theme-terminal.git

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,8 +1,7 @@
 baseURL = 'https://tabasku.github.io/'
 languageCode = 'en-us'
-title = 'Joni’s blog'
-theme = 'typo'
-colorPalette = 'default'
+title = 'Joni's blog'
+theme = 'terminal'
 
 [taxonomies]
 tag = 'tags'
@@ -11,36 +10,11 @@ tag = 'tags'
     author = "Joni Kurunsaari"
     description = "Blogging about stuff I want to learn and remember"
 
-# Appearance settings
-theme = 'auto'
-colorPalette = 'default'
-hideHeader = false
-
-# Intro on main page, content in markdown
-homeIntroTitle = 'Moi!'
-homeIntroContent = """
-Blogging about stuff I want to learn and remember
-"""
-
-singleDateFormat = '2 Jan 2006'
-
-# Collection to display on home
-# homeCollectionTitle = 'Posts'
-# homeCollection = 'posts'
-
-# Lists parameters
-paginationSize = 100
-listSummaries = true
-listDateFormat = '02 Jan 2006'
-
-# Footer
-showFooter = false
-
-# Breadcrumbs
-[params.breadcrumbs]
-enabled = true
-showCurrentPage = true
-home = "~"
+    # Terminal theme settings
+    contentTypeName = "posts"
+    showMenuItems = 3
+    fullWidthTheme = false
+    centerTheme = false
 
 # Social icons
 [[params.social]]
@@ -52,31 +26,27 @@ name = "github"
 url = "https://github.com/tabasku"
 
 # Main menu pages
-# [[params.menu]]
-# name = "home"
-# url = "/"
-
-[[params.menu]]
-name = "posts"
+[[menu.main]]
+identifier = "posts"
+name = "Posts"
 url = "/posts"
 
-[[params.menu]]
-name = "about"
+[[menu.main]]
+identifier = "about"
+name = "About"
 url = "/about"
 
-[[params.menu]]
-name = "library"
+[[menu.main]]
+identifier = "library"
+name = "Library"
 url = "/library"
-
-# [[params.menu]]
-# name = "tags"
-# url = "/tags"
 
 
 # Syntax highlight on code blocks
+# Required for Terminal theme and Chroma highlighting
 [markup]
 [markup.highlight]
-style = 'bw'
+noClasses = false
 
 # Deploy settings
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = 'https://tabasku.github.io/'
 languageCode = 'en-us'
-title = 'Joni's blog'
+title = "Joni's blog"
 theme = 'terminal'
 
 [taxonomies]


### PR DESCRIPTION
- Added hugo-theme-terminal as git submodule
- Updated hugo.toml to use the Terminal theme
- Configured Terminal theme with proper settings
- Updated menu structure to work with Terminal theme
- Set up Chroma syntax highlighting for Terminal theme

The Terminal theme provides a simple, retro aesthetic with monospace fonts and a minimalist terminal-style design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)